### PR TITLE
Being explicit about the validity of a plus sign in a DSDL constant definition

### DIFF
--- a/Specification/3._Data_structure_description_language.md
+++ b/Specification/3._Data_structure_description_language.md
@@ -172,12 +172,12 @@ A constant must be assigned with a constant initializer, which must be one of th
 
 * Integer zero (0).
 * Integer literal in base 10, starting with a non-zero character. E.g., 123, -12.
-* Integer literal in base 16 prefixed with `0x`. E.g., 0x123, -0x12.
-* Integer literal in base 2 prefixed with `0b`. E.g., 0b1101, -0b101101.
-* Integer literal in base 8 prefixed with `0o`. E.g., 0o123, -0o777.
+* Integer literal in base 16 prefixed with `0x`. E.g., 0x123, -0x12, +0x123.
+* Integer literal in base 2 prefixed with `0b`. E.g., 0b1101, -0b101101, +0b101101.
+* Integer literal in base 8 prefixed with `0o`. E.g., 0o123, -0o777, +0o777.
 * Floating point literal. Fractional part with an optional exponent part, e.g.,
-`15.75`, `1.575E1`, `1575e-2`, `-2.5e-3`, `25E-4`.
-Note that the use of infinity and NAN (not-a-number) is discouraged as it may not be supported on all platforms.
+`15.75`, `1.575E1`, `1575e-2`, `-2.5e-3`, `+25E-4`.
+Not-a-number (NaN) and infinities are intentionally not supported in order to maximize cross-platform compatibility.
 * Boolean `true` or `false`.
 * Single ASCII character, ASCII escape sequence, or ASCII hex literal in single quotes. E.g., `'a'`, `'\x61'`, `'\n'`.
 

--- a/Specification/3._Data_structure_description_language.md
+++ b/Specification/3._Data_structure_description_language.md
@@ -177,7 +177,7 @@ A constant must be assigned with a constant initializer, which must be one of th
 * Integer literal in base 8 prefixed with `0o`. E.g., 0o123, -0o777, +0o777.
 * Floating point literal. Fractional part with an optional exponent part, e.g.,
 `15.75`, `1.575E1`, `1575e-2`, `-2.5e-3`, `+25E-4`.
-Not-a-number (NaN) and infinities are intentionally not supported in order to maximize cross-platform compatibility.
+Not-a-number (NaN), positive infinity, and negative infinity are intentionally not supported in order to maximize cross-platform compatibility.
 * Boolean `true` or `false`.
 * Single ASCII character, ASCII escape sequence, or ASCII hex literal in single quotes. E.g., `'a'`, `'\x61'`, `'\n'`.
 


### PR DESCRIPTION
See https://github.com/UAVCAN/uavcan.rs/pull/30#discussion_r149468623

Relevant piece of the Python compiler: https://github.com/UAVCAN/pyuavcan/blob/b8bc90b53d81538191d29e4d6c61b4a5cb8cf925/uavcan/dsdl/parser.py#L712-L723